### PR TITLE
zyre: use CONAN_PKG targets

### DIFF
--- a/recipes/zyre/2.0.0/CMakeLists.txt
+++ b/recipes/zyre/2.0.0/CMakeLists.txt
@@ -1,7 +1,11 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0)
 project(conanzyre)
 
 include(conanbuildinfo.cmake)
 conan_basic_setup()
+
+if(NOT BUILD_SHARED_LIBS)
+    add_definitions(-DZYRE_STATIC)
+endif()
 
 add_subdirectory(source_subfolder)

--- a/recipes/zyre/2.0.0/conandata.yml
+++ b/recipes/zyre/2.0.0/conandata.yml
@@ -6,3 +6,7 @@ patches:
   "2.0.0":
       - patch_file: "patches/0001-cmake-use-conan-disable-executables.patch"
         base_path: "source_subfolder"
+      - patch_file: "patches/0002-zyre-disable-git-escape-CMAKE_BUILD_TYPE.patch"
+        base_path: "source_subfolder"
+      - patch_file: "patches/0003-fix-zyre-self-test.patch"
+        base_path: "source_subfolder"

--- a/recipes/zyre/2.0.0/conanfile.py
+++ b/recipes/zyre/2.0.0/conanfile.py
@@ -24,7 +24,7 @@ class ZyreConan(ConanFile):
         "fPIC": True,
         "drafts": False,
     }
-    generators = ["cmake"]
+    generators = ["cmake", "cmake_find_package"]
     _cmake = None
     _source_subfolder = "source_subfolder"
     _build_subfolder = "build_subfolder"
@@ -42,6 +42,7 @@ class ZyreConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
+        self._cmake.verbose = True
         self._cmake.definitions["ENABLE_DRAFTS"] = self.options.drafts
         self._cmake.configure(build_dir=self._build_subfolder)
         return self._cmake
@@ -61,3 +62,5 @@ class ZyreConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["zyre"]
+        if not self.options.shared:
+            self.cpp_info.defines = ["ZYRE_STATIC"]

--- a/recipes/zyre/2.0.0/patches/0001-cmake-use-conan-disable-executables.patch
+++ b/recipes/zyre/2.0.0/patches/0001-cmake-use-conan-disable-executables.patch
@@ -1,13 +1,17 @@
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -109,8 +109,8 @@ set(OPTIONAL_LIBRARIES)
+@@ -107,10 +107,10 @@ set(OPTIONAL_LIBRARIES)
  ########################################################################
- find_package(libzmq REQUIRED)
- IF (LIBZMQ_FOUND)
+ # LIBZMQ dependency
+ ########################################################################
+-find_package(libzmq REQUIRED)
++find_package(ZeroMQ REQUIRED)
+-IF (LIBZMQ_FOUND)
++IF (ZEROMQ_FOUND)
 -    include_directories(${LIBZMQ_INCLUDE_DIRS})
 -    list(APPEND MORE_LIBRARIES ${LIBZMQ_LIBRARIES})
 +    include_directories(${CONAN_INCLUDE_DIRS_LIBZMQ})
-+    list(APPEND MORE_LIBRARIES ${CONAN_LIBS_LIBZMQ})
++    list(APPEND MORE_LIBRARIES ZeroMQ::ZeroMQ)
      set(pkg_config_libs_private "${pkg_config_libs_private} -lzmq")
  ELSE (LIBZMQ_FOUND)
      message( FATAL_ERROR "libzmq not found." )
@@ -18,10 +22,19 @@
 -    include_directories(${CZMQ_INCLUDE_DIRS})
 -    list(APPEND MORE_LIBRARIES ${CZMQ_LIBRARIES})
 +    include_directories(${CONAN_INCLUDE_DIRS_CZMQ})
-+    list(APPEND MORE_LIBRARIES ${CONAN_LIBS_CZMQ})
++    list(APPEND MORE_LIBRARIES czmq::czmq)
      set(pkg_config_libs_private "${pkg_config_libs_private} -lczmq")
  ELSE (CZMQ_FOUND)
      message( FATAL_ERROR "czmq not found." )
+@@ -168,7 +168,7 @@
+ endif()
+ add_library(zyre ${zyre_sources})
+ set_target_properties(zyre
+-    PROPERTIES DEFINE_SYMBOL "ZYRE_EXPORTS"
++    PROPERTIES DEFINE_SYMBOL "ZYRE_EXPORTS" LINKER_LANGUAGE CXX
+ )
+ set_target_properties (zyre
+     PROPERTIES SOVERSION "2.0.0"
 @@ -182,9 +182,9 @@ install(TARGETS zyre
      ARCHIVE DESTINATION "lib${LIB_SUFFIX}" # .lib file
      RUNTIME DESTINATION bin              # .dll file

--- a/recipes/zyre/2.0.0/patches/0002-zyre-disable-git-escape-CMAKE_BUILD_TYPE.patch
+++ b/recipes/zyre/2.0.0/patches/0002-zyre-disable-git-escape-CMAKE_BUILD_TYPE.patch
@@ -1,0 +1,20 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -22,7 +22,7 @@
+ ########################################################################
+ # options
+ ########################################################################
+-if (NOT CMAKE_BUILD_TYPE)
++if (0)
+     if (EXISTS "${SOURCE_DIR}/.git")
+         set (CMAKE_BUILD_TYPE Debug)
+     else ()
+@@ -43,7 +43,7 @@
+         endif ()
+     endif ()
+ endif ()
+-if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
++if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+     OPTION (ENABLE_DRAFTS "Build and install draft classes and methods" ON)
+ else ()
+     OPTION (ENABLE_DRAFTS "Build and install draft classes and methods" OFF)

--- a/recipes/zyre/2.0.0/patches/0003-fix-zyre-self-test-on-windows.patch
+++ b/recipes/zyre/2.0.0/patches/0003-fix-zyre-self-test-on-windows.patch
@@ -1,0 +1,55 @@
+https://github.com/zeromq/czmq/commit/8f8aa86ec1ecf903a614a26aa9e4dd63ace4ffd1
+
+--- src/zre_msg.c
++++ src/zre_msg.c
+@@ -1766,4 +1766,7 @@
+     //  @end
+ 
++#ifdef __WINDOWS__    
++    zsys_shutdown();
++#endif
+     printf ("OK\n");
+ }
+--- src/zyre.c
++++ src/zyre.c
+@@ -738,6 +738,9 @@
+     zyre_destroy (&node2);
+     //  @end
++#ifdef __WINDOWS__    
++    zsys_shutdown();
++#endif
+     printf ("OK\n");
+ 
+     // zre_msg, zyre_group, zyre_node and zyre_peer are private classes and
+     // symbols are not exported so the tests can't be run from zyre_selftest,
+--- src/zyre_group.c
++++ src/zyre_group.c
+@@ -171,5 +171,8 @@
+     zhash_destroy (&groups);
+     zsock_destroy (&mailbox);
++#ifdef __WINDOWS__    
++    zsys_shutdown();
++#endif
+     printf ("OK\n");
+ }
+ 
+--- src/zyre_node.c
++++ src/zyre_node.c
+@@ -1022,4 +1022,7 @@
+     zsock_destroy (&pipe);
+     //  Node takes ownership of outbox and destroys it
++#ifdef __WINDOWS__    
++    zsys_shutdown();
++#endif
+     printf ("OK\n");
+ }
+--- src/zyre_peer.c
++++ src/zyre_peer.c
+@@ -475,4 +475,7 @@
+     zsock_destroy (&mailbox);
+ 
++#ifdef __WINDOWS__    
++    zsys_shutdown();
++#endif
+     printf ("OK\n");
+ }


### PR DESCRIPTION
- CCI provides zeromq, not libzmq
- the `CONAN_LIBS_CZMQ` variables do not contain the transitive dependent libraries.